### PR TITLE
Added support for listing repository languages

### DIFF
--- a/src/data/repos.languages.xml
+++ b/src/data/repos.languages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<languages>
+  <Ruby type="integer">136905</Ruby>
+</languages>

--- a/src/githubtest.py
+++ b/src/githubtest.py
@@ -213,6 +213,13 @@ class RepoTest(BaseCase):
         self.assertEquals(4, len(bl))
         self.assertEquals('ee90922f3da3f67ef19853a0759c1d09860fe3b3', bl['master'])
 
+    def testLanguageList(self):
+        """Test language listing for a repo."""
+        bl = self._gh('https://github.com/api/v2/xml/repos/show/schacon/ruby-git/languages',
+                      'data/repos.languages.xml').repos.languages('schacon', 'ruby-git')
+        self.assertEquals(1, len(bl))
+        self.assertEquals('136905', bl['Ruby'])
+
     def testGetOneRepo(self):
         """Fetch an individual repository."""
         r = self._gh('https://github.com/api/v2/xml/repos/show/schacon/grit',


### PR DESCRIPTION
Adds support for listing repo languages. Nearly identical to fetching branches with one catch: Github API XML output can be malformed for some languages, necessitating hacking the _fetch function. Languages can contain characters not allowed in XML tags, which breaks the XML parser e.g. for https://github.com/api/v2/json/repos/show/facebook/hiphop-php/languages. Instead of the cheap replace method implemented here it would be cleaner to rewrite py-github using the json format or asking github to fix the XML output.

So yeah, this is the quickest fix and is actually robust enough.
