### PR TITLE
adding urlencode to namespace of file to correct exception in BaseEndpoint

### DIFF
--- a/github/github.py
+++ b/github/github.py
@@ -43,6 +43,8 @@ import xml.dom.minidom
 try: import simplejson as json
 except ImportError: import json
 
+from urllib import urlencode
+
 import hclient
 
 def _string_parser(x):


### PR DESCRIPTION
In BaseEndpoint._post (line:~312) urlencode is called when not in the namespace. Throws exception NameError: global name 'urlencode' is not defined
